### PR TITLE
Auto binding when uninitialized and RSSI over PPM

### DIFF
--- a/frsky_arduino_rx_complete.ino
+++ b/frsky_arduino_rx_complete.ino
@@ -547,6 +547,11 @@ void binding()
             for (i = 0; i < 2; i++) {
                 txid[i] = EEPROM.read(adr + i);
             }
+            if (txid[0] == 0xff && txid[1] == 0xff) {
+                // No valid txid, forcing bind
+                jumper2 = 1;
+                continue;
+            }
             for (i = 0; i < sizeof(hopData); i++) {
                 hopData[i] = EEPROM.read(adr + 10 + i);
             }


### PR DESCRIPTION
The auto binding thing is mostly because my setup is kind of broken and I can't use the bind pin (reboots the naze this is connected to).  It seems convenient, though.

RSSI over PPM is a little experimental.  I don't fully understand what it's doing.  We could probably come up with some better values.  In the meantime, it's just 1000-2000 for the best and worst signal we've seen (defaulting to the best and worst I've been able to produce in my casual testing).
