### PR TITLE
New failsafe code to stop sending pulses on failure.

### DIFF
--- a/frsky_arduino_rx_complete.ino
+++ b/frsky_arduino_rx_complete.ino
@@ -227,10 +227,6 @@ void loop()
             for (i = 0; i < 8; i++) {
                 Servo_data[i] = 1000;
                 ppm[i] = 1000;
-                if (i == 2) {
-                    Servo_data[2] = 1000; //THROTLE ON CHN3 here it can be changed Throttle on other channel
-                    ppm[2] = 1000;
-                }
             }
         }
     #endif


### PR DESCRIPTION
I tested failure and recovery on this.  Behavior seems to match D4R observed behavior.

D4R capture:
![D4R](https://cloud.githubusercontent.com/assets/1779/8074326/89fc8852-0ee5-11e5-8a78-c27114eec023.png)

Opensky capture:
![Opensky](https://cloud.githubusercontent.com/assets/1779/8074327/95a85d48-0ee5-11e5-9891-bacc10633394.png)
